### PR TITLE
Set post author in RSS feed according to post

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -11,7 +11,7 @@ layout: none
         {% for post in site.posts limit:10 %}
             <item>
                 <title>{{ post.title }}</title>
-                <author>Steve Gattuso</author>
+                <author>{{ post.author }}</author>
                 <description>{{ post.content | xml_escape }}</description>
                 <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
                 <link>http://rochack.org{{ post.url }}</link>


### PR DESCRIPTION
Each post has its own author, so we can use that when generating the xml feed.
