### PR TITLE
Add makefile and test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+site:
+	jekyll build
+
+.build.out: .FORCE
+	jekyll build 2>&1 | tee $@
+
+test: .build.out
+	! grep -q Error $<
+
+.PHONY: .FORCE


### PR DESCRIPTION
This allows the project to be more easily tested. Along with the [CI](https://developer.github.com/guides/building-a-ci-server/) [server](https://github.com/clehner/simple-gh-ci) that I've enabled on this repo, we should now see a status on pull requests of whether a build succeeds or not. This will work by the CI server running `make test` in the background on the proposed pull-request branch.

In particular this should help catch issues like whitespace problems before they get pushed to master and break the site.